### PR TITLE
Feat/case studies page

### DIFF
--- a/app/case-studies/code-coach-culture-case/page.tsx
+++ b/app/case-studies/code-coach-culture-case/page.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable react/no-unescaped-entities */
+import { Main } from "@/components/ui/Spacer";
+import Title, { Subtitle, Text } from "@/components/ui/Typography";
+
+export default function CodeCoachCultureCase() {
+  return (
+    <Main gap="md">
+        <a href="/case-studies"> 
+            <Text size="sm" color="secondary">← Back to Case Studies</Text>
+        </a><br/>
+      <Title>Code.Coach.Culture: Case Study</Title>
+      <Text>
+        Project: Code.Coach.Culture — A Blog Platform for Developers and Leaders
+      </Text>
+      <Text>
+        Live Site:{" "}
+        <span className="italic font-semibold">
+          <a href="https://code-coach-culture.vercel.app">
+            code-coach-culture.vercel.app
+          </a>
+        </span>
+      </Text>
+      <Text>Stack: Next.js 14, MDX, Tailwind CSS, Framer Motion, Vercel</Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+      <Subtitle>🎯 The Concept</Subtitle>
+      <Text size="buttonText">
+        For years, I dreamed of starting a blog—but I didn’t just want to write
+        posts. I wanted to create a platform that reflected my identity: part
+        software developer, part leadership coach, and fully committed to
+        excellence in people and systems.
+      </Text>
+      <Text size="buttonText">
+        As someone with over 20 years of customer service experience and more
+        than a decade in leadership, I’ve spent my career developing people,
+        managing operations, and driving performance. When I transitioned into
+        software development, I initially felt like I had to leave that part of
+        myself behind. But the deeper I got into coding, the more I realized
+        those experiences gave me a powerful edge in design thinking, system
+        planning, and intentional problem-solving.
+      </Text>
+      <Text size="buttonText">
+        <span className="font-bold">Code.Coach.Culture</span> was born to bring
+        those worlds together. It’s a personal blog—but also a technical case
+        study in how to design with clarity, scale, and heart.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🧱 Planning & Structure</Subtitle>
+      <Text size="buttonText">
+        I broke the project down like a real product:
+      </Text>
+      <ul className="list-disc ml-10">
+        <li>
+          <span className="font-semibold">Categories:</span> I created 4 main
+          content pillars:Dev Diaries, Leadership Logs, Ops & Strategy, and Mind
+          & Motivation
+        </li>
+        <li>
+          <span className="font-semibold">Content System:</span> I chose MDX for
+          blog post storage—keeping it lightweight and future-proof while
+          allowing rich content formatting and custom components
+        </li>
+        <li>
+          <span className="font-semibold">Routing:</span> Leveraged Next.js App
+          Router for clean URL structures like /dev-diaries/[slug]
+        </li>
+        <li>
+          <span className="font-semibold">Reusability:</span>Reusability:
+          Componentized layouts and utilities like Hero, CategoryLinks, and
+          PostCard
+        </li>
+        <li>
+          <span className="font-semibold">Style:</span> Used TailwindCSS for
+          consistent, expressive design with mobile responsiveness baked in
+        </li>
+        <li>
+          <span className="font-semibold">Hosting:</span> Deployed to Vercel
+          with static site generation using generateStaticParams
+        </li>
+      </ul>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🧠 Learning & Challenges</Subtitle>
+      <Text size="buttonText">
+        This wasn’t just a project—it was a journey. I had to:
+      </Text>
+      <ul className="list-disc ml-10">
+        <li>Learn how to use MDX inside a modern Next.js setup</li>
+        <li>Debug hydration errors and route mismatches</li>
+        <li>Structure my content for growth, not just MVP</li>
+        <li>
+          Think like a frontend engineer while moving with the mindset of an
+          operator
+        </li>
+        <li>
+          Use AI (ChatGPT) to help me solve problems faster and understand best
+          practices
+        </li>
+      </ul>
+      <Text size="buttonText">
+        With every obstacle, I built new skills: understanding how to map files
+        to routes, pre-render with static generation, use semantic HTML, and
+        write clean, responsive design.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🚀 Deployment & Results</Subtitle>
+      <Text size="buttonText">Once the site was built, I:</Text>
+      <ul className="list-disc ml-10">
+        <li>Ran local builds with npm run build to confirm stability</li>
+        <li>Deployed to Vercel with GitHub integration</li>
+        <li>Validated every route, post, and component</li>
+        <li>Created a polished README.md and opened the repo to the public</li>
+      </ul>
+      <Text size="buttonText">
+        What I launched wasn’t just a blog. It was a portfolio piece, a
+        conversation starter, and a digital home for my unique blend of skills.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🌟 Why It Matters</Subtitle>
+      <Text>
+        <span className="font-bold">Code.Coach.Culture</span> is more than code.
+        It’s my blueprint.
+      </Text>
+      <Text size="buttonText">
+        I’ve stopped separating who I was from who I’m becoming. This platform
+        is proof that technical growth and people development can coexist—and
+        even strengthen each other.
+      </Text>
+      <Text size="buttonText">
+        For recruiters and potential clients, it’s a window into my mind: how I
+        build, how I lead, and how I think.
+      </Text>
+      <Text size="buttonText">
+        If you're looking for someone who can connect dots between customer
+        experience, team leadership, and scalable software—this is the case
+        study you were meant to see.
+      </Text>
+    </Main>
+  );
+}

--- a/app/case-studies/movifind-case/page.tsx
+++ b/app/case-studies/movifind-case/page.tsx
@@ -1,0 +1,151 @@
+/* eslint-disable react/no-unescaped-entities */
+import { Main } from "@/components/ui/Spacer";
+import Title, { Subtitle, Text } from "@/components/ui/Typography";
+
+export default function MoviFindCase() {
+  return (
+    <Main gap="md">
+      <a href="/case-studies">
+        <Text size="sm" color="secondary">
+          ← Back to Case Studies
+        </Text>
+      </a>
+      <br />
+
+      <Title>📽️ MoviFind: Case Study</Title>
+      <Text>
+        Live Site:{" "}
+        <span>
+          <a href="https://movifind.vercel.app">https://movifind.vercel.app</a>
+        </span>
+      </Text>
+      <Text>Stack: Next.js 14, TypeScript, Tailwind CSS, TMDB API, Vercel</Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🧠 The Idea</Subtitle>
+      <Text size="buttonText">
+        MoviFind was inspired by a real request from a friend who loved watching
+        movie trailers but didn’t want the hassle of searching YouTube or
+        relying on word-of-mouth. She said,{" "}
+        <span className="italic font-semibold">
+          “I just want a simple site to go to and discover new movies. I don’t
+          want it bulky, just something clean and easy to use.”
+        </span>{" "}
+        That became my north star.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🎯 The Goal</Subtitle>
+      <ul className="list-disc ml-10">
+        <li>
+          Create a centralized platform to discover and preview new movies,
+          especially trailers.
+        </li>
+        <li>Make it familiar and intuitive, like Netflix, but lighter.</li>
+        <li>Stay focused on just the essentials for Version 1 (MVP).</li>
+        <li>Leave room to grow based on real feedback.</li>
+      </ul>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🔨 The Build Journey</Subtitle>
+      <Text>1. Version 1 Misstep</Text>
+      <Text size="buttonText">
+        I initially built a version that intentionally avoided Netflix's layout,
+        trying to be overly unique. The result? A clunky, confusing app that
+        didn’t meet the goal. I wasn’t listening — I was building what I thought
+        she wanted.
+      </Text>
+      <Text>2. Pivot & Realignment</Text>
+      <Text size="buttonText">
+        I paused, reconnected with the original request, and decided to lean
+        into familiarity. Netflix’s layout is effective for a reason. I
+        redesigned the homepage to feel like a clean, tailored Netflix — but
+        with my own flavor.
+      </Text>
+      <Text>3. Feature Focus</Text>
+      <ul className="list-disc ml-10">
+        <li className="italic">
+          Featured Banner with trailer button in a modal
+        </li>
+        <li className="italic">
+          Top Rated, Now Playing, and Upcoming sections
+        </li>
+        <li className="italic">Genre filtering for better discovery</li>
+        <li className="italic">Movie details page for deeper exploration</li>
+        <li className="italic">Fallback images to handle missing posters</li>
+        <li className="italic">Modal design system for scalability</li>
+        <li className="italic">
+          TMDB API as the sole source of reliable, updated movie data
+        </li>
+      </ul>
+      <Text>4. Refinement & Deployment</Text>
+      <Text size="buttonText">
+        As I built, I hit real-world issues: API key configs, layout
+        inconsistencies, image scaling, and parameter errors. I worked through
+        them with live debugging, console logs, and some help from AI. When all
+        features were stable, I deployed to Vercel and did one final pass for
+        polish.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🤖 AI as a Coding Partner</Subtitle>
+      <Text size="buttonText">
+        Throughout development, I used AI (ChatGPT) as a second brain:
+      </Text>
+      <ul className="list-disc ml-10">
+        <li className="italic">
+          For API strategy, error handling, and refactoring
+        </li>
+        <li className="italic">To debug issues in real time</li>
+        <li className="italic">
+          To think through architecture before I wrote code
+        </li>
+      </ul>
+      <Text size="buttonText">
+        It was like having a senior dev pair-program with me — guiding when I
+        was stuck, but letting me drive.
+      </Text>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>📈 Outcomes</Subtitle>
+      <ul className="list-disc ml-10">
+        <li>
+          Delivered a clean, intuitive MVP that’s already getting real user
+          feedback.
+        </li>
+        <li>
+          Reaffirmed that listening to the user matters more than trying to
+          impress with over-complexity.
+        </li>
+        <li>
+          Proved my ability to build and deploy a full-stack app with real data,
+          modern tech, and thoughtful UI.
+        </li>
+      </ul>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🔄 Next Steps: Version 2</Subtitle>
+      <Text size="buttonText">Planned updates based on feedback:</Text>
+      <ul className="list-disc ml-10">
+        <li>Search bar</li>
+        <li>Better trailer discovery</li>
+        <li>Watchlist</li>
+        <li>Personalized recommendations</li>
+      </ul>
+      <hr className="w-full border-t border-gray-600 my-6" />
+
+      <Subtitle>🧾 Lessons Learned</Subtitle>
+      <ul className="list-disc ml-10">
+        <li>Don't reinvent what already works. Familiarity is usability.</li>
+        <li>Always go back to the core user need.</li>
+        <li>
+          Small wins (like fallback images or modals) add up to a polished UX.
+        </li>
+        <li>
+          Using AI as a partner accelerates learning and delivery without
+          replacing deep thinking.
+        </li>
+      </ul>
+    </Main>
+  );
+}

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -1,0 +1,12 @@
+import { Main } from "@/components/ui/Spacer";
+import CaseStudiesHero from "@/components/case-studies/CaseStudiesHero";
+import CaseStudiesList from "@/components/case-studies/CaseStudesList";
+
+export default function CaseStudies() {
+    return (
+        <Main gap="xxl">
+            <CaseStudiesHero />
+            <CaseStudiesList />
+        </Main>
+    )
+}

--- a/components/case-studies/CaseStudesList.tsx
+++ b/components/case-studies/CaseStudesList.tsx
@@ -1,0 +1,20 @@
+import Card from "@/components/ui/Card";
+import { Subtitle } from "../ui/Typography";
+import { caseStudiesList } from "@/data/casestudies";
+import Link from "next/link";
+
+export default function CaseStudiesList() {
+    return (
+        <>
+            {caseStudiesList.map((caseStudy) => (
+                <Link  key={caseStudy.slug} href={caseStudy.href}>
+                    <Card className="flex flex-col gap-2">
+                        <Subtitle align="center">{caseStudy.title}</Subtitle>
+                        {caseStudy.summary}
+                    </Card>
+                </Link>
+                ))}
+                
+        </>
+    )
+}

--- a/components/case-studies/CaseStudiesHero.tsx
+++ b/components/case-studies/CaseStudiesHero.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import Title, { Text } from "@/components/ui/Typography";
 import { FlexContainer } from "../ui/Spacer";
 

--- a/components/case-studies/CaseStudiesHero.tsx
+++ b/components/case-studies/CaseStudiesHero.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/no-unescaped-entities */
+import Title, { Text } from "@/components/ui/Typography";
+import { FlexContainer } from "../ui/Spacer";
+
+export default function CaseStudiesHero() {
+  return (
+    <FlexContainer flex="column" gap="md">
+      <Title>Case Studies Page</Title>
+      <Text size="buttonText">
+        Case Studies give clients and recruiters a deeper look into how I think,
+        build, and solve problems — not just what I’ve shipped. Instead of
+        listing tools and features, I break down the strategy, design choices,
+        and real-world challenges behind each project. It’s not just a portfolio
+        — it’s proof of impact.
+      </Text>
+    </FlexContainer>
+  );
+}

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -15,7 +15,7 @@ export default function ProjectCard() {
             <Container className="flex justify-center">
               <Image
                 src={project.img}
-                alt="image of MoviFind App"
+                alt={`${project.title} screenshot`}
                 width={300}
                 height={200}
                 className="object-cover h-[200px] overflow-hidden"

--- a/data/casestudies.tsx
+++ b/data/casestudies.tsx
@@ -1,0 +1,44 @@
+import { Text } from "@/components/ui/Typography";
+import { ReactNode } from "react";
+
+export type CaseStudiesType = {
+  title: string;
+  slug: string;
+  href: string;
+  summary: ReactNode;
+  img?: string[];
+};
+
+export const caseStudiesList: CaseStudiesType[] = [
+  {
+    title: "Code.Coach.Culture",
+    slug: "code-coach-culture",
+    href: "/case-studies/code-coach-culture-case",
+    summary: (
+      <>
+        <Text size="caption">
+          Code.Coach.Culture is my personal brand where I blend 20+ years of
+          leadership with full-stack development. It highlights my work, growth,
+          and values—focusing on clean code, user-first design, and building
+          culture through tech.{" "}
+        </Text>
+      </>
+    ),
+    img: [],
+  },
+  {
+    title: "MoviFind Web App",
+    slug: "movifind-web-app",
+    href: "/case-studies/movifind-case",
+    summary: (
+      <>
+        <Text size="caption">
+          MoviFind is a Netflix-inspired movie discovery app built with Next.js,
+          Tailwind CSS, and the TMDB API. The app allows users to explore
+          trending and top-rated movies in a sleek, mobile-friendly UI.
+        </Text>
+      </>
+    ),
+    img: [],
+  },
+];


### PR DESCRIPTION
🗂️ Feature: Case Studies Route with Detail Pages & Navigation

Summary:
This PR sets up a dedicated /case-studies route showcasing in-depth project highlights. Each case study is summarized in a card layout and links to its own detailed page.
🔧 What’s Included:

    New Route: /case-studies to display all available case study summaries

    Case Study Cards:

        Created summary cards for:

            Code.Coach.Culture

            MoviFind

        Each card includes title, brief overview, and a link to the full case study page

    Detail Pages:

        Standalone pages for each case study with expanded context and project insights

        Included a “Back to Case Studies” link for seamless navigation

🧭 Navigation Flow:

    Visitors land on /case-studies

    Click any card to view full project insights

    Use the “Back” link to return to the overview page without friction

✅ Confirmed Working:

    ✅ Case study cards render dynamically

    ✅ Internal links route correctly to detail pages

    ✅ “Back to Case Studies” link navigates as expected

    ✅ Styling and layout match the existing site framework****