### PR TITLE
Fix Tailwind styling imports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "../ui-framework/styles/fonts.css";
+@import "../ui-framework/theme/globals.css";
 
 /* :root {
   --background: #ffffff;

--- a/ui-framework/index.ts
+++ b/ui-framework/index.ts
@@ -1,4 +1,2 @@
-import "./styles/fonts.css";
-import "./styles/globals.css";
 export * from "./theme";
 export * from "./components";


### PR DESCRIPTION
## Summary
- import UI framework font and theme styles in `app/globals.css`
- remove global CSS imports from `ui-framework/index.ts`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts, module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685685cb7c68832aa503a3140be0a092